### PR TITLE
feat: logic for packet parsing function

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ To run:
 2. Run `nvm install latest` to install the latest version of nodeJS.
 3. Run `nvm use latest` to set up node for use.
 4. Using a command line, run `npm install` in the project root to install all dependencies.
-5. Run `npm parse-success` to run the parser with the valid test file, `npm parse-failure` to run the parser with the invalid test file, or `npm test` to run the suite of Jest tests.
+5. Run `npm run parse-success` to run the parser with the valid test file, `npm run parse-failure` to run the parser with the invalid test file, or `npm test` to run the suite of Jest tests.

--- a/web/mpegtspacketParser.js
+++ b/web/mpegtspacketParser.js
@@ -1,6 +1,16 @@
 export const mpegtsPacketParser = (packet, streamOffset, seq) => {
-  console.log(packet)
-  console.log(streamOffset)
-  console.log(seq)
-}
+    if(packet.length === 0) return null
+    if(packet[0] !== 0x47 && seq > 0) { 
+      console.log(`Error: No Sync Byte present in Packet ${seq} at offset ${streamOffset}.`) 
+      process.exit(1)
+    }
+    if(packet[1] === undefined || packet[2] === undefined) {
+        console.log(`Error: Incomplete PID in Packet ${seq} at offset ${streamOffset}`)
+        process.exit(1)
+    }
+    if(packet.length < 188 && seq === 0) return null
+    const lsb5 = packet[1] & parseInt('00011111', 2)
+    const pid = parseInt(lsb5.toString(2) + packet[2].toString(2).padStart(8, '0'), 2)
+    return { pid, payload: packet }
+  }
   

--- a/web/webLayerSimulator.js
+++ b/web/webLayerSimulator.js
@@ -8,6 +8,10 @@ import { createReadStream } from 'fs'
 import { mpegtsPacketParser } from './mpegtspacketParser.js'
 
 const webLayerSimulator = (fileName) => {
+  const pidList = new Set()
+  let seq  = 0
+  let offset = 0
+  const fileData = ""
   try{
     var inputStream = createReadStream(fileName, { highWaterMark: 188 })
     inputStream.on('error', ({message}) => {
@@ -16,10 +20,17 @@ const webLayerSimulator = (fileName) => {
     })
 
     inputStream.on('data', (packet) => {
-      mpegtsPacketParser(packet, offset, seq)
+      const parsed = mpegtsPacketParser(packet, offset, seq)
+      if(parsed) {
+        fileData.concat(parsed.payload)
+        pidList.add(parsed.pid) 
+        offset += packet.length
+        ++seq 
+      }
     })
 
     inputStream.on('end', () => {
+      Array.from(pidList).sort().map((elem) => console.log(`0x${elem.toString(16)}`))
       inputStream.removeAllListeners()
       process.exit(0)
     })


### PR DESCRIPTION
Implements the logic for the parser function

AC1: When the parser is run with a valid stream, print out the PIDs formatted as hex bytes in ascending order.
AC2: When the parser is run with only a single incomplete packet that is still valid, return null and do nothing.
AC3: When the parser is run with a stream that contains a packet beyond the first that is missing its sync byte, print the packet sequence number & offset in bytes and exit with error code 1.
AC4: When the parser is run with a stream that contains an incomplete initial packet, but is otherwise valid, parse successfully & print the PIDs hex ascending order as usual.
AC5: When the parser is run with a packet that has an incomplete PID, exit with error code 1.
AC6: When the parser is run with a null value (I.E. Empty stream), the parser should return null as a defensive measure. (The web layer would probably implicitly prevent this if the stream never received data)