### PR TITLE
feat: logger interface

### DIFF
--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,0 +1,5 @@
+const logger = (msg) => {
+    console.log(msg)
+}
+
+export { logger }

--- a/web/mpegtspacketParser.js
+++ b/web/mpegtspacketParser.js
@@ -1,11 +1,13 @@
+import { logger } from '../utils/logger.js'
+
 export const mpegtsPacketParser = (packet, streamOffset, seq) => {
     if(packet.length === 0) return null
     if(packet[0] !== 0x47 && seq > 0) { 
-      console.log(`Error: No Sync Byte present in Packet ${seq} at offset ${streamOffset}.`) 
+      logger(`Error: No Sync Byte present in Packet ${seq} at offset ${streamOffset}.`) 
       process.exit(1)
     }
     if(packet[1] === undefined || packet[2] === undefined) {
-        console.log(`Error: Incomplete PID in Packet ${seq} at offset ${streamOffset}`)
+        logger(`Error: Incomplete PID in Packet ${seq} at offset ${streamOffset}`)
         process.exit(1)
     }
     if(packet.length < 188 && seq === 0) return null

--- a/web/webLayerSimulator.js
+++ b/web/webLayerSimulator.js
@@ -6,6 +6,7 @@
 
 import { createReadStream } from 'fs'
 import { mpegtsPacketParser } from './mpegtspacketParser.js'
+import { logger } from '../utils/logger.js'
 
 const webLayerSimulator = (fileName) => {
   const pidList = new Set()
@@ -15,7 +16,7 @@ const webLayerSimulator = (fileName) => {
   try{
     var inputStream = createReadStream(fileName, { highWaterMark: 188 })
     inputStream.on('error', ({message}) => {
-      console.log(message)
+      logger(message)
       process.exit(1)
     })
 
@@ -30,12 +31,12 @@ const webLayerSimulator = (fileName) => {
     })
 
     inputStream.on('end', () => {
-      Array.from(pidList).sort().map((elem) => console.log(`0x${elem.toString(16)}`))
+      Array.from(pidList).sort().map((elem) => logger(`0x${elem.toString(16)}`))
       inputStream.removeAllListeners()
       process.exit(0)
     })
   } catch (ex) {
-    console.log(ex)
+    logger(ex)
   }
 }
 


### PR DESCRIPTION
Provides an abstraction over the logger so it can be swapped out if/when needed.

AC1: In all places where console.log would have been called, logger will be called instead.